### PR TITLE
Remove instruction to install dependencies

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -21,14 +21,7 @@ To run your own MOTIS instance, you need an OpenStreetMap dataset and a timetabl
 
 Tested on Ubuntu 18.04.
 
-  - **Step 1**: Install a new C++ standard library required by MOTIS.
-{% highlight bash %}
-apt install -y --no-install-recommends apt-utils software-properties-common
-add-apt-repository -y ppa:ubuntu-toolchain-r/test
-apt update
-apt upgrade -y
-{% endhighlight %}
-  - **Step 2**: Download the MOTIS distribution from [here](https://github.com/motis-project/motis/releases/latest/download/motis-linux-amd64.tar.bz2) and extract it. The directory structure must look exactly like the one shown on the right.
+  - **Step 1**: Download the MOTIS distribution from [here](https://github.com/motis-project/motis/releases/latest/download/motis-linux-amd64.tar.bz2) and extract it. The directory structure must look exactly like the one shown on the right.
   - **Start MOTIS**: `./motis/motis` and visit [http://localhost:8080](http://localhost:8080).
 
 


### PR DESCRIPTION
As the new release does not need those dependencies anymore, we can drop them from the installation instructions.

This resolves  #6