### PR TITLE
Update post to fix 404 link

### DIFF
--- a/_posts/2021-12-29-gtfs-rt-multi-schedule-release.markdown
+++ b/_posts/2021-12-29-gtfs-rt-multi-schedule-release.markdown
@@ -71,6 +71,6 @@ while true; do
 done
 ```
 
-We are working on improving the documentation ([here](https://motis-project.de/docs)] and in the [GitHub Wiki](https://github.com/motis-project/motis/wiki)) for more complex MOTIS setups. Please feel free to ask questions via the GitHub [issues](https://github.com/motis-project/motis/issues).
+We are working on improving the documentation ([here](https://motis-project.de/docs/api) and in the [GitHub Wiki](https://github.com/motis-project/motis/wiki)) for more complex MOTIS setups. Please feel free to ask questions via the GitHub [issues](https://github.com/motis-project/motis/issues).
 
 We are working on improving the support for GTFS and GTFS-RT, for example by moving the download functionality directly into MOTIS so the update script above won't be necessary anymore. Furthermore, we are looking forward to next year where we will see [GBFS](https://github.com/NABSA/gbfs)-support in MOTIS as well as a new data model supporting timetables with arbitrary length (at least 1-2 years) in an memory-efficient manner. The work on these features is sponsored by [INIT](https://initse.com).


### PR DESCRIPTION
The link to the documentation did resolve in a 404. Updated it to link to the documentation page as intended.