### PR TITLE
Update routing.md: Fix outdated link

### DIFF
--- a/docs/features/routing.md
+++ b/docs/features/routing.md
@@ -41,4 +41,4 @@ MOTIS also contains variants of these algorithms which are not described in the 
 
 ### Try it out live:
 
-  - [Demo](https://switzerland.motis-project.de)
+  - [Demo](https://europe.motis-project.de/)


### PR DESCRIPTION
When going through the docs, I found this outdated link.