### PR TITLE
Remove mentions of Android App from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,9 +88,8 @@ layout: default
         <h5 class="card-title">Web and App</h5>
         <p class="card-text">
           To demonstrate the API, MOTIS provides a <a
-            href="https://europe.motis-project.de/">web application</a> and an <a
-            href="https://play.google.com/store/apps/details?id=de.motis_project.demo">Android
-            app</a>. Both provide capabilities for intermodal real-time routing.
+            href="https://europe.motis-project.de/">web application</a> which 
+          provides capabilities for intermodal real-time routing.
           Everything is <a href="https://github.com/motis-project/motis/tree/master/ui">open
             source</a> as well and can be hacked on!
         </p>
@@ -103,9 +102,6 @@ layout: default
             href="https://github.com/motis-project/motis/tree/master/ui">GitHub
             Link</a>
           <a href="https://europe.motis-project.de/">Web Demo</a>
-          <a
-            href="https://play.google.com/store/apps/details?id=de.motis_project.demo">Android
-            App</a>
         </small>
       </div>
     </div>


### PR DESCRIPTION
The App is gone from the Play Store and afaik won't be resurrected so the link can be removed.